### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ django-teledex
 .. _Coverage Status: https://coveralls.io/r/alexhayes/django-teledex?branch=master
 .. |Code Status| image:: https://landscape.io/github/alexhayes/django-teledex/master/landscape.png
 .. _Code Status: https://landscape.io/github/alexhayes/django-teledex/
-.. |PyPi version| image:: https://pypip.in/v/django-teledex/badge.png
+.. |PyPi version| image:: https://img.shields.io/pypi/v/django-teledex.svg
 .. _PyPi version: https://pypi.python.org/pypi/django-teledex
-.. |PyPi downloads| image:: https://pypip.in/d/django-teledex/badge.png
+.. |PyPi downloads| image:: https://img.shields.io/pypi/dm/django-teledex.svg
 .. _PyPi downloads: https://pypi.python.org/pypi/django-teledex
 
 ``django-teledex`` supports Python 2.7, 3.3, 3.4 and pypy for Django 1.7 and 1.8.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-teledex))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-teledex`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.